### PR TITLE
Matias branch

### DIFF
--- a/app/src/main/java/com/programabit/mediguard/data/services/MyFirebaseMessagingService.java
+++ b/app/src/main/java/com/programabit/mediguard/data/services/MyFirebaseMessagingService.java
@@ -61,6 +61,7 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
             switch (title) {
                 case "NUEVA GUARDIA DISPONIBLE":
                     Intent toAvaibleGuards = new Intent(this, AvaibleGuardsActivity.class).putExtra("token", token);
+                    toAvaibleGuards.putExtra("notification", true);
                     TaskStackBuilder stackBuilder = TaskStackBuilder.create(this);
                     stackBuilder.addNextIntentWithParentStack(toAvaibleGuards);
                     PendingIntent resultPendingIntent =
@@ -83,6 +84,7 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
                 case "GUARDIA ASIGNADA":
                     //Intent para que al presionar notificacion lleve al usuario a Mis Guardias
                     Intent toMyGuards = new Intent(this, MyGuardsActivity.class).putExtra("token", token);
+                    toMyGuards.putExtra("notification", true);
                     TaskStackBuilder AsignadaStackBuilder = TaskStackBuilder.create(this);
                     AsignadaStackBuilder.addNextIntentWithParentStack(toMyGuards);
                     PendingIntent toMyGuardsPendingIntent =

--- a/app/src/main/java/com/programabit/mediguard/data/services/MyFirebaseMessagingService.java
+++ b/app/src/main/java/com/programabit/mediguard/data/services/MyFirebaseMessagingService.java
@@ -18,6 +18,7 @@ import com.google.firebase.messaging.RemoteMessage;
 import com.programabit.mediguard.R;
 import com.programabit.mediguard.data.preferences.TokenPreference;
 import com.programabit.mediguard.ui.AvaibleGuardsActivity;
+import com.programabit.mediguard.ui.DashboardActivity;
 import com.programabit.mediguard.ui.MyGuardsActivity;
 
 import java.time.LocalDate;
@@ -61,8 +62,9 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
 
             switch (title) {
                 case "NUEVA GUARDIA DISPONIBLE":
-                    Intent toAvaibleGuards = new Intent(this, AvaibleGuardsActivity.class).putExtra("token", token);
+                    Intent toAvaibleGuards = new Intent(this, DashboardActivity.class).putExtra("data", token);
                     toAvaibleGuards.putExtra("notification", true);
+                    toAvaibleGuards.putExtra("notif_type", "avalibe");
                     TaskStackBuilder stackBuilder = TaskStackBuilder.create(this);
                     stackBuilder.addNextIntentWithParentStack(toAvaibleGuards);
                     PendingIntent resultPendingIntent =
@@ -85,7 +87,9 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
                 case "GUARDIA ASIGNADA":
                     //Intent para que al presionar notificacion lleve al usuario a Mis Guardias
                     Intent toMyGuards = new Intent(this, MyGuardsActivity.class).putExtra("token", token);
+                    //Intent toMyGuards = new Intent(this, DashboardActivity.class).putExtra("data", token); // <- no arregla bug
                     toMyGuards.putExtra("notification", true);
+                    toMyGuards.putExtra("notif_type", "assigned");
                     TaskStackBuilder AsignadaStackBuilder = TaskStackBuilder.create(this);
                     AsignadaStackBuilder.addNextIntentWithParentStack(toMyGuards);
                     PendingIntent toMyGuardsPendingIntent =

--- a/app/src/main/java/com/programabit/mediguard/ui/AvaibleGuardsActivity.java
+++ b/app/src/main/java/com/programabit/mediguard/ui/AvaibleGuardsActivity.java
@@ -12,6 +12,7 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.programabit.mediguard.R;
 import com.programabit.mediguard.data.preferences.GuardCountPreference;
+import com.programabit.mediguard.data.preferences.TokenPreference;
 import com.programabit.mediguard.domain.AvaibleGuardViewModel;
 import com.programabit.mediguard.domain.GuardDto;
 
@@ -38,9 +39,9 @@ public class AvaibleGuardsActivity extends BaseActivity {
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
         Intent intent = getIntent();
 
-        if(intent.getExtras() != null) {
-            myToken = (intent.getStringExtra("token"));
-        }
+        TokenPreference tokenPreference = new TokenPreference(this);
+        myToken = tokenPreference.getToken();
+
         Log.i("My Guards Activity","got token");
         guardsViewModel = new ViewModelProvider(this,
                 new AvaibleGuardsFactory(this.getApplication(), myToken))

--- a/app/src/main/java/com/programabit/mediguard/ui/BaseActivity.java
+++ b/app/src/main/java/com/programabit/mediguard/ui/BaseActivity.java
@@ -86,7 +86,6 @@ public abstract class BaseActivity extends AppCompatActivity {
         } else if (itemId == R.id.mLogoff) {
             TokenPreference preferences = new TokenPreference(this);
             preferences.saveToken("");
-            clearAppData();
             startActivity(new Intent(this, LoginActivity.class));
             finish();
             return true;

--- a/app/src/main/java/com/programabit/mediguard/ui/BaseActivity.java
+++ b/app/src/main/java/com/programabit/mediguard/ui/BaseActivity.java
@@ -1,6 +1,7 @@
 package com.programabit.mediguard.ui;
 
 import android.content.Intent;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 
@@ -70,6 +71,7 @@ public abstract class BaseActivity extends AppCompatActivity {
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         int itemId = item.getItemId();
         if (itemId == android.R.id.home) {
+            notificationIntentChecker();
             finish();
             return true;
         } else if (itemId == R.id.mSettings && layoutID != R.layout.activity_user_settings) {
@@ -89,6 +91,22 @@ public abstract class BaseActivity extends AppCompatActivity {
             return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    private void notificationIntentChecker() {
+        Intent intent = getIntent();
+        if(intent.getExtras() != null) {
+            try {
+                boolean isNotification = getIntent().getExtras().getBoolean("notification");
+                if (isNotification) {
+                    String myToken = (intent.getStringExtra("token"));
+                    startActivity(new Intent(this,DashboardActivity.class).putExtra("data",myToken));
+                }
+            } catch (Exception e) {
+                Log.i("Back Button exception", "No estas volviendo desde una nofiticación" + e);
+                e.printStackTrace();
+            }
+        }
     }
 
     private boolean finishCurrent() {

--- a/app/src/main/java/com/programabit/mediguard/ui/BaseActivity.java
+++ b/app/src/main/java/com/programabit/mediguard/ui/BaseActivity.java
@@ -86,11 +86,27 @@ public abstract class BaseActivity extends AppCompatActivity {
         } else if (itemId == R.id.mLogoff) {
             TokenPreference preferences = new TokenPreference(this);
             preferences.saveToken("");
+            clearAppData();
             startActivity(new Intent(this, LoginActivity.class));
             finish();
             return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    public void clearAppData() {
+        try {
+            // clearing app data
+            //TokenPreference preferences = new TokenPreference(this);
+            //preferences.saveToken("");
+            this.getSharedPreferences("KEY_COUNT", 0).edit().clear().apply();
+            this.getSharedPreferences("KEY_TOKEN", 0).edit().clear().apply();
+            String packageName = getApplicationContext().getPackageName();
+            Runtime runtime = Runtime.getRuntime();
+            runtime.exec("pm clear "+packageName);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
     }
 
     private void notificationIntentChecker() {

--- a/app/src/main/java/com/programabit/mediguard/ui/DashboardActivity.java
+++ b/app/src/main/java/com/programabit/mediguard/ui/DashboardActivity.java
@@ -87,7 +87,16 @@ public class DashboardActivity extends BaseActivity {
         } catch(Exception e) {
             TokenPreference preferences = new TokenPreference(this);
             preferences.saveToken("");
-            this.getSharedPreferences("KEY_TOKEN", 0).edit().clear().apply();
+            //this.getSharedPreferences("KEY_TOKEN", 0).edit().clear().apply();
+            try {
+                // clearing app data
+                String packageName = getApplicationContext().getPackageName();
+                Runtime runtime = Runtime.getRuntime();
+                runtime.exec("pm clear "+packageName);
+
+            } catch (Exception ex) {
+                ex.printStackTrace();
+            }
             Log.i("DASHBOARD","posiblemente token no existe o no valido: " + e);
             startActivity(new Intent(DashboardActivity.this,LoginActivity.class));
             finish();

--- a/app/src/main/java/com/programabit/mediguard/ui/DashboardActivity.java
+++ b/app/src/main/java/com/programabit/mediguard/ui/DashboardActivity.java
@@ -109,6 +109,10 @@ public class DashboardActivity extends BaseActivity {
 
         String TAG = "DashboardActivity";
 
+        //redirigir a guardias disponibles o asignadas si ee intent proviene de una notificacion
+        checkIfIsNotificationIntent();
+
+
         FirebaseMessaging.getInstance().subscribeToTopic(Integer.toString(myself.getCi()))
                 .addOnCompleteListener(task -> {
                     String msg = getString(R.string.notification_success_msg);
@@ -131,6 +135,26 @@ public class DashboardActivity extends BaseActivity {
                     Log.d(TAG, msg);
                     Toast.makeText(DashboardActivity.this, msg, Toast.LENGTH_SHORT).show();
                 });
+    }
+
+    private void checkIfIsNotificationIntent() {
+        Intent intent = getIntent();
+        if(intent.getExtras() != null) {
+            String notificationType;
+            try {
+                notificationType = getIntent().getStringExtra("notif_type");
+                String myToken = getIntent().getStringExtra("token");
+                if (notificationType.equals("avalibe")) {
+                    startActivity(new Intent(this,AvaibleGuardsActivity.class).putExtra("token",myToken));
+                    onPause();
+                } /*else if (notificationType.equals("assigned")) {
+                    startActivity(new Intent(this,MyGuardsActivity.class).putExtra("token",myToken));
+                }*/
+            } catch (Exception e) {
+                Log.i("Back Button exception", "No estas volviendo desde una nofiticación" + e);
+                e.printStackTrace();
+            }
+        }
     }
 
     private void setGuardCountMessage(int guardsNum) {

--- a/app/src/main/java/com/programabit/mediguard/ui/DashboardActivity.java
+++ b/app/src/main/java/com/programabit/mediguard/ui/DashboardActivity.java
@@ -87,16 +87,7 @@ public class DashboardActivity extends BaseActivity {
         } catch(Exception e) {
             TokenPreference preferences = new TokenPreference(this);
             preferences.saveToken("");
-            //this.getSharedPreferences("KEY_TOKEN", 0).edit().clear().apply();
-            try {
-                // clearing app data
-                String packageName = getApplicationContext().getPackageName();
-                Runtime runtime = Runtime.getRuntime();
-                runtime.exec("pm clear "+packageName);
-
-            } catch (Exception ex) {
-                ex.printStackTrace();
-            }
+            clearAppData();
             Log.i("DASHBOARD","posiblemente token no existe o no valido: " + e);
             startActivity(new Intent(DashboardActivity.this,LoginActivity.class));
             finish();


### PR DESCRIPTION
**### Fix:**

-App se cerraba cuando se abre la notificacion y se asigna guardia disponible sin tener previamente la app abierta

-Metodo clearAppData() para borrar Shared Preferences

-Arreglo de Back Button (físico y toolbar), no volvía al dashboard desde Avalible_Guards cuando se abre una notificación. 

-Arreglo temporal para error DoInBackground, se eliminan los datos de la app cuando crashea el dashboard (se borraba solo el token, ahora borra todos los datos de la app, para prevenir problemas cuando inica)


**### Bug conocido:**

-Aplicación se cierra, cuando volves al dashboard con el botón fisico, desde la notificacion "GUARDIA ASIGNADA". (Solo sucede si se entra a la notificación con la app cerrada)